### PR TITLE
Adds /event/covid parameter for COVID site info

### DIFF
--- a/event_links.rb
+++ b/event_links.rb
@@ -79,5 +79,13 @@ module FrcLinks
     get /\/(c|cmp|championship)/i do
       redirect "https://www.firstchampionship.org"
     end
+    
+    # Redirects to the COVID information for the given event.
+    get /\/(e|event)\/(v|covid)\/([A-Za-z]+\d?)(\/(\d+))?/i do
+      event = params["captures"][2]
+      year = params["captures"][4] || default_year
+      redirect "http://firstinspires.org/sites/default/files/uploads/frc/#{year}-events/#{year}_" +
+          "#{event.upcase}_SiteInfo.pdf"
+    end
   end
 end


### PR DESCRIPTION
Adds /event/covid (short form /e/v) for COVID site information.

Example URL is:
https://www.firstinspires.org/sites/default/files/uploads/frc/2022-events/2022_MNDU_SiteInfo.pdf

Follows same model as agenda.